### PR TITLE
Correção de bug ao atribuir o localStorage vazio em this.contatos

### DIFF
--- a/src/app/services/contato.service.ts
+++ b/src/app/services/contato.service.ts
@@ -25,8 +25,10 @@ export class ContatoService {
     const contatosLocalStorageString = localStorage.getItem('contatos');
     const contatosLocalStorage =
       contatosLocalStorageString ? JSON.parse(contatosLocalStorageString) : null;
-
-    this.contatos = contatosLocalStorage || null;
+    //A condição abaixo previne que na primeira execução da app em um novo navegador o localStorage não seja carregado.
+    if (contatosLocalStorage !== null) {
+      this.contatos = contatosLocalStorage || null;
+    }
 
     //Salvar os contatos no localStorage
     localStorage.setItem('contatos', JSON.stringify(this.contatos));


### PR DESCRIPTION
Na primeira execução da app, o local storage estará vazio, portanto o código estará sempre sobrescrevendo o valor definido na inicialização de contatos pelo conteúdo do localStorage que nesse contexto é null.